### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ cd ..
 rosdep install --from-paths src -i
 catkin_make
 ```
+If the error 'ROS distro is not set' appear, you should add rosdistro option:
+```sh
+rosdep install --from-paths src -i --rosdistro=kinetic
+```
 The build process should end with no errors. If there is any, you should verify if you are working in the correct workspace:
 ```sh
 echo $ROS_PACKAGE_PATH

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ source devel/setup.bash
 ```
 The  `catkin_make ` command build all the packages that are in the catkin_ws/src folder. We source `devel/setup.bash` to add our new workspace to $ROS_PACKAGE_PATH enviroment variable. We might want to have the configuration to be charge always we open a new bash session:
 ```sh
-echo "source /home/<username>/catkin_ws/devel/setup.bash" >> ~/.bashrc
+echo "source /opt/ros/kinetic/setup.bash" >> ~/.bashrc
 source ~/.bashrc
 ```
 We also might have permission troubles with directories. For not hav any issue, give to your user all permission over /.ros directory:

--- a/README.md
+++ b/README.md
@@ -64,11 +64,14 @@ cd ~/catkin_ws/src
 git clone https://github.com/AutonomyLab/ardrone_autonomy.git
 cd ..
 rosdep install --from-paths src -i
-catkin_make
 ```
-If the error 'ROS distro is not set' appear, you should add rosdistro option:
+If the error 'ROS distro is not set' appear, you should add --rosdistro option:
 ```sh
 rosdep install --from-paths src -i --rosdistro=kinetic
+```
+If no errors appear, continue with
+```sh
+catkin_make
 ```
 The build process should end with no errors. If there is any, you should verify if you are working in the correct workspace:
 ```sh


### PR DESCRIPTION
Rearrange the command for ROS environment variables.
Manage error of 'ROS distro is not set' (probably derived from the wrong source of the ROS environment variables)